### PR TITLE
Class refactoring

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["rewire"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,8 @@
     "describe": true,
     "before": true,
     "after": true,
-    "it": true
+    "it": true,
+    "should": true,
+    "browser": true
   }
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
                 options: {
                     scriptPath: require.resolve('isparta/bin/isparta'),
                     reporter: 'spec',
-                    mochaOptions: ['--compilers', 'js:babel/register', '--recursive'],
+                    mochaOptions: ['--compilers', 'js:babel/register', '--recursive', '-t', '60000'],
                     require: ['should']
                 }
             }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import Mocha from 'mocha'
 
-import { runInFiberContext, wrapCommand, runHook, wrapFn } from 'wdio-sync'
+import { runInFiberContext, wrapCommands, executeHooksWithArgs } from 'wdio-sync'
 
 const INTERFACES = {
     bdd: ['before', 'beforeEach', 'it', 'after', 'afterEach'],
@@ -45,24 +45,15 @@ class MochaAdapter {
         mocha.loadFiles()
         delete this.runner.lastError
         mocha.reporter(NOOP)
+        this.specs.forEach((spec) => mocha.addFile(spec))
 
         this.requireExternalModules(this.config.mochaOpts.compilers, this.config.mochaOpts.requires)
-
-        const hooks = {
-            beforeHook: wrapFn(this.wrapHook.bind(this, 'beforeHook', 'internal')),
-            afterHook: wrapFn(this.wrapHook.bind(this, 'afterHook', 'internal')),
-            beforeCommand: wrapFn(this.wrapHook.bind(this, 'beforeCommand', 'internal')),
-            afterCommand: wrapFn(this.wrapHook.bind(this, 'afterCommand', 'internal'))
-        }
-
-        wrapCommand(global.browser, hooks)
-
-        this.specs.forEach((spec) => mocha.addFile(spec))
+        wrapCommands(global.browser, this.config.beforeCommand, this.config.afterCommand)
         mocha.suite.on('pre-require', () => INTERFACES[this.config.mochaOpts.ui].forEach(
-            runInFiberContext.bind(null, INTERFACES, this.config.mochaOpts.ui, hooks))
+            runInFiberContext.bind(null, INTERFACES, this.config.mochaOpts.ui, this.config.beforeHook, this.config.afterHook))
         )
 
-        await this.wrapHook('before')
+        await executeHooksWithArgs(this.config.before, [this.capabilities, this.specs])
         let result = await new Promise((resolve, reject) => {
             this.runner = mocha.run(resolve)
 
@@ -74,49 +65,36 @@ class MochaAdapter {
             this.runner.suite.afterEach(this.wrapHook('afterTest', 'test'))
             this.runner.suite.afterAll(this.wrapHook('afterSuite', 'suite'))
         })
-        await this.wrapHook('after')
+        await executeHooksWithArgs(this.config.after, [this.capabilities, this.specs])
         return result
     }
 
-    wrapHook (hookName, hookType, data = {}) {
-        const hookFn = this.config[hookName]
-
-        // Hooks which are added as true Mocha hooks need to call done() to notify async
-        // completion.
-        if (['test', 'suite'].indexOf(hookType) >= 0) {
-            return (done) => {
-                const boundHook = hookFn.bind(null, this.prepareMessage(hookName, hookType, data))
-                runHook(boundHook, done)
-            }
-        }
-        const boundHook = hookFn.bind(null, this.prepareMessage(hookName, hookType, data))
-        return runHook(boundHook)
+    /**
+     * Hooks which are added as true Mocha hooks need to call done() to notify async
+     */
+    wrapHook (hookName, hookType, ...data) {
+        return (done) => executeHooksWithArgs(
+            this.config[hookName],
+            this.prepareMessage(hookName, hookType, data)
+        ).then(() => done())
     }
 
-    prepareMessage (hookName, hookType, data = {}) {
+    prepareMessage (hookName, hookType, data) {
         const params = { type: hookName, data }
+        let payload
 
-        if (this.runner) {
-            let payload
-            switch (hookType) {
-            case 'suite':
-                payload = this.runner.suite.suites[0]
-                break
-            case 'test':
-                payload = this.runner.test
-                break
-            default:
-                payload = this.runner.currentRunnable
-                break
-            }
-
-            params.payload = payload
-            params.err = this.runner.lastError
-
-        // Useful to know the actual spec files currently being run
-        } else if (hookName === 'before') {
-            params.data.specs = this.specs
+        switch (hookType) {
+        case 'suite':
+            payload = this.runner.suite.suites[0]
+            break
+        case 'test':
+            payload = this.runner.test
+            break
         }
+
+        params.payload = payload
+        params.err = this.runner.lastError
+        params.data.push(this.specs)
 
         return this.formatMessage(params)
     }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -22,170 +22,184 @@ const EVENTS = {
 
 const NOOP = function () {}
 
-let adapter = {}
-
 /**
  * Mocha runner
  */
-adapter.run = async function mochaAdapter (cid, config = { mochaOpts: {} }, specs = [], capabilities) {
-    let compilers = config.mochaOpts.compilers
-    let requires = config.mochaOpts.require
-    let runner
-
-    function prepareMessage (hookName, hookType, data = {}) {
-        const params = {type: hookName, data}
-
-        if (runner) {
-            let payload
-            switch (hookType) {
-            case 'suite':
-                payload = runner.suite.suites[0]
-                break
-
-            case 'test':
-                payload = runner.test
-                break
-
-            default:
-                payload = runner.currentRunnable
-                break
-            }
-
-            params.payload = payload
-            params.err = runner.lastError
-            delete runner.lastError
-
-        // Useful to know the actual spec files currently being run
-        } else if (hookName === 'before') {
-            params.data.specs = specs
-        }
-
-        return adapter.formatMessage(params)
+class MochaAdapter {
+    constructor (cid, config, specs, capabilities) {
+        this.cid = cid
+        this.capabilities = capabilities
+        this.specs = specs
+        this.config = Object.assign({
+            mochaOpts: {}
+        }, config)
+        this.runner = null
     }
 
-    function wrapHook (hookName, hookType, data = {}) {
-        const hookFn = config[hookName]
+    async run () {
+        if (typeof this.config.mochaOpts.ui !== 'string' || !this.config.mochaOpts.ui.match(/(bdd|tdd)/i)) {
+            this.config.mochaOpts.ui = 'bdd'
+        }
+
+        const mocha = new Mocha(this.config.mochaOpts)
+        mocha.loadFiles()
+        delete this.runner.lastError
+        mocha.reporter(NOOP)
+
+        this.requireExternalModules(this.config.mochaOpts.compilers, this.config.mochaOpts.requires)
+
+        const hooks = {
+            beforeHook: wrapFn(this.wrapHook.bind(this, 'beforeHook', 'internal')),
+            afterHook: wrapFn(this.wrapHook.bind(this, 'afterHook', 'internal')),
+            beforeCommand: wrapFn(this.wrapHook.bind(this, 'beforeCommand', 'internal')),
+            afterCommand: wrapFn(this.wrapHook.bind(this, 'afterCommand', 'internal'))
+        }
+
+        wrapCommand(global.browser, hooks)
+
+        this.specs.forEach((spec) => mocha.addFile(spec))
+        mocha.suite.on('pre-require', () => INTERFACES[this.config.mochaOpts.ui].forEach(
+            runInFiberContext.bind(null, INTERFACES, this.config.mochaOpts.ui, hooks))
+        )
+
+        await this.wrapHook('before')
+        let result = await new Promise((resolve, reject) => {
+            this.runner = mocha.run(resolve)
+
+            Object.keys(EVENTS).forEach((e) =>
+                this.runner.on(e, this.emit.bind(this, EVENTS[e])))
+
+            this.runner.suite.beforeAll(this.wrapHook('beforeSuite', 'suite'))
+            this.runner.suite.beforeEach(this.wrapHook('beforeTest', 'test'))
+            this.runner.suite.afterEach(this.wrapHook('afterTest', 'test'))
+            this.runner.suite.afterAll(this.wrapHook('afterSuite', 'suite'))
+        })
+        await this.wrapHook('after')
+        return result
+    }
+
+    wrapHook (hookName, hookType, data = {}) {
+        const hookFn = this.config[hookName]
 
         // Hooks which are added as true Mocha hooks need to call done() to notify async
         // completion.
         if (['test', 'suite'].indexOf(hookType) >= 0) {
-            return function (done) {
-                const boundHook = hookFn.bind(null, prepareMessage(hookName, hookType, data))
+            return (done) => {
+                const boundHook = hookFn.bind(null, this.prepareMessage(hookName, hookType, data))
                 runHook(boundHook, done)
             }
         }
-        const boundHook = hookFn.bind(null, prepareMessage(hookName, hookType, data))
+        const boundHook = hookFn.bind(null, this.prepareMessage(hookName, hookType, data))
         return runHook(boundHook)
     }
 
-    if (typeof config.mochaOpts.ui !== 'string' || !config.mochaOpts.ui.match(/(bdd|tdd)/i)) {
-        config.mochaOpts.ui = 'bdd'
-    }
+    prepareMessage (hookName, hookType, data = {}) {
+        const params = { type: hookName, data }
 
-    const mocha = new Mocha(config.mochaOpts)
-    mocha.loadFiles()
-    mocha.fullTrace()
-    mocha.reporter(NOOP)
+        if (this.runner) {
+            let payload
+            switch (hookType) {
+            case 'suite':
+                payload = this.runner.suite.suites[0]
+                break
+            case 'test':
+                payload = this.runner.test
+                break
+            default:
+                payload = this.runner.currentRunnable
+                break
+            }
 
-    adapter.requireExternalModules(compilers, requires)
+            params.payload = payload
+            params.err = this.runner.lastError
 
-    const hooks = {
-        beforeHook: wrapFn(wrapHook.bind(null, 'beforeHook', 'internal')),
-        afterHook: wrapFn(wrapHook.bind(null, 'afterHook', 'internal')),
-        beforeCommand: wrapFn(wrapHook.bind(null, 'beforeCommand', 'internal')),
-        afterCommand: wrapFn(wrapHook.bind(null, 'afterCommand', 'internal'))
-    }
-
-    wrapCommand(global.browser, hooks)
-
-    specs.forEach((spec) => mocha.addFile(spec))
-    mocha.suite.on('pre-require', () => INTERFACES[config.mochaOpts.ui].forEach(runInFiberContext.bind(null, INTERFACES, config.mochaOpts.ui, hooks)))
-
-    await wrapHook('before')
-    let result = await new Promise((resolve, reject) => {
-        runner = mocha.run(resolve)
-        Object.keys(EVENTS).forEach((e) => runner.on(e, adapter.emit.bind(null, EVENTS[e], runner, cid, capabilities)))
-
-        runner.suite.beforeAll(wrapHook('beforeSuite', 'suite'))
-        runner.suite.beforeEach(wrapHook('beforeTest', 'test'))
-        runner.suite.afterEach(wrapHook('afterTest', 'test'))
-        runner.suite.afterAll(wrapHook('afterSuite', 'suite'))
-    })
-    await wrapHook('after')
-    return result
-}
-
-adapter.requireExternalModules = function (compilers = [], requires = []) {
-    compilers.concat(requires).forEach((mod) => {
-        mod = mod.split(':')
-        mod = mod[mod.length - 1]
-
-        if (mod[0] === '.') {
-            mod = path.join(process.cwd(), mod)
+        // Useful to know the actual spec files currently being run
+        } else if (hookName === 'before') {
+            params.data.specs = this.specs
         }
 
-        adapter.load(mod)
-    })
-}
-
-adapter.formatMessage = function (params) {
-    let message = {
-        type: params.type
+        return this.formatMessage(params)
     }
 
-    if (params.err) {
-        message.err = {
-            message: params.err.message,
-            stack: params.err.stack
+    formatMessage (params) {
+        let message = {
+            type: params.type
+        }
+
+        if (params.err) {
+            message.err = {
+                message: params.err.message,
+                stack: params.err.stack
+            }
+        }
+
+        if (params.payload) {
+            message.title = params.payload.title
+            message.parent = params.payload.parent ? params.payload.parent.title : null
+            message.pending = params.payload.pending || false
+            message.file = params.payload.file
+            message.duration = params.payload.duration
+            message.passed = (params.payload.state === 'passed')
+        }
+
+        if (params.data) {
+            message = Object.assign(message, params.data)
+        }
+
+        return message
+    }
+
+    requireExternalModules (compilers = [], requires = []) {
+        compilers.concat(requires).forEach((mod) => {
+            mod = mod.split(':')
+            mod = mod[mod.length - 1]
+
+            if (mod[0] === '.') {
+                mod = path.join(process.cwd(), mod)
+            }
+
+            this.load(mod)
+        })
+    }
+
+    emit (event, payload, err) {
+        let message = this.formatMessage({type: event, payload, err})
+
+        message.cid = this.cid
+        message.event = event
+        message.runner = {}
+        message.runner[this.cid] = this.capabilities
+
+        if (err) {
+            this.runner.lastError = err
+        } else if (event === 'test:start') {
+            delete this.runner.lastError
+        }
+        this.send(message)
+    }
+
+    /**
+     * reset globals to rewire it out in tests
+     */
+    send (...args) {
+        return process.send.apply(process, args)
+    }
+
+    load (module) {
+        try {
+            require(module)
+        } catch (e) {
+            throw new Error(`Module ${module} can't get loaded. Are you sure you have installed it?\n` +
+                            `Note: if you've installed WebdriverIO globally you need to install ` +
+                            `these external modules globally too!`)
         }
     }
-
-    if (params.payload) {
-        message.test = {
-            title: params.payload.title,
-            parent: params.payload.parent ? params.payload.parent.title : null,
-            pending: params.payload.pending || false,
-            file: params.payload.file,
-            duration: params.payload.duration,
-            passed: (params.payload.state === 'passed')
-        }
-    }
-
-    if (params.data) {
-        for (let key in params.data) {
-            message[key] = params.data[key]
-        }
-    }
-
-    return message
 }
 
-adapter.emit = function (event, runner, cid, capabilities, payload, err) {
-    let message = adapter.formatMessage({type: event, payload, err})
-
-    message.cid = cid
-    message.event = event
-    message.runner = {}
-    message.runner[cid] = capabilities
-
-    if (err) {
-        runner.lastError = err
-    }
-    adapter.send(message)
+const adapterFactory = {}
+adapterFactory.run = async function mochaAdapter (cid, config, specs, capabilities) {
+    const adapter = new MochaAdapter(cid, config, specs, capabilities)
+    return await adapter.run()
 }
 
-/**
- * reset globals to rewire it out in tests
- */
-adapter.send = (process.send || NOOP).bind(process)
-adapter.load = function (module) {
-    try {
-        require(module)
-    } catch (e) {
-        throw new Error(`Module ${module} can't get loaded. Are you sure you have installed it?\n` +
-                        `Note: if you've installed WebdriverIO globally you need to install ` +
-                        `these external modules globally too!`)
-    }
-}
-
-export default adapter
+export default adapterFactory

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -121,8 +121,11 @@ class MochaAdapter {
             message.parent = params.payload.parent ? params.payload.parent.title : null
             message.pending = params.payload.pending || false
             message.file = params.payload.file
-            message.duration = params.payload.duration
-            message.passed = (params.payload.state === 'passed')
+
+            if (params.type.match(/Test/)) {
+                message.passed = (params.payload.state === 'passed')
+                message.duration = params.payload.duration
+            }
         }
 
         return message

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -65,10 +65,10 @@ class MochaAdapter {
             Object.keys(EVENTS).forEach((e) =>
                 this.runner.on(e, this.emit.bind(this, EVENTS[e])))
 
-            this.runner.suite.beforeAll(this.wrapHook('beforeSuite', 'suite'))
-            this.runner.suite.beforeEach(this.wrapHook('beforeTest', 'test'))
-            this.runner.suite.afterEach(this.wrapHook('afterTest', 'test'))
-            this.runner.suite.afterAll(this.wrapHook('afterSuite', 'suite'))
+            this.runner.suite.beforeAll(this.wrapHook('beforeSuite'))
+            this.runner.suite.beforeEach(this.wrapHook('beforeTest'))
+            this.runner.suite.afterEach(this.wrapHook('afterTest'))
+            this.runner.suite.afterAll(this.wrapHook('afterSuite'))
         })
         await executeHooksWithArgs(this.config.after, [this.capabilities, this.specs])
         return result
@@ -77,30 +77,28 @@ class MochaAdapter {
     /**
      * Hooks which are added as true Mocha hooks need to call done() to notify async
      */
-    wrapHook (hookName, hookType, ...data) {
+    wrapHook (hookName) {
         return (done) => executeHooksWithArgs(
             this.config[hookName],
-            this.prepareMessage(hookName, hookType, data)
+            this.prepareMessage(hookName)
         ).then(() => done())
     }
 
-    prepareMessage (hookName, hookType, data) {
-        const params = { type: hookName, data }
-        let payload
+    prepareMessage (hookName, hookType) {
+        const params = { type: hookName }
 
         switch (hookType) {
-        case 'suite':
-            payload = this.runner.suite.suites[0]
+        case 'beforeSuite':
+        case 'afterSuite':
+            params.payload = this.runner.suite.suites[0]
             break
-        case 'test':
-            payload = this.runner.test
+        case 'beforeTest':
+        case 'afterTest':
+            params.payload = this.runner.test
             break
         }
 
-        params.payload = payload
         params.err = this.runner.lastError
-        params.data.push(this.specs)
-
         return this.formatMessage(params)
     }
 
@@ -123,10 +121,6 @@ class MochaAdapter {
             message.file = params.payload.file
             message.duration = params.payload.duration
             message.passed = (params.payload.state === 'passed')
-        }
-
-        if (params.data) {
-            message = Object.assign(message, params.data)
         }
 
         return message

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5,7 +5,8 @@ import { runInFiberContext, wrapCommands, executeHooksWithArgs } from 'wdio-sync
 
 const INTERFACES = {
     bdd: ['before', 'beforeEach', 'it', 'after', 'afterEach'],
-    tdd: ['suiteSetup', 'setup', 'test', 'suiteTeardown', 'teardown']
+    tdd: ['suiteSetup', 'setup', 'test', 'suiteTeardown', 'teardown'],
+    qunit: ['before', 'beforeEach', 'test', 'after', 'afterEach']
 }
 
 const EVENTS = {
@@ -37,7 +38,7 @@ class MochaAdapter {
     }
 
     async run () {
-        if (typeof this.config.mochaOpts.ui !== 'string' || !this.config.mochaOpts.ui.match(/(bdd|tdd)/i)) {
+        if (typeof this.config.mochaOpts.ui !== 'string' || !INTERFACES[this.config.mochaOpts.ui]) {
             this.config.mochaOpts.ui = 'bdd'
         }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -34,7 +34,7 @@ class MochaAdapter {
         this.config = Object.assign({
             mochaOpts: {}
         }, config)
-        this.runner = null
+        this.runner = {}
     }
 
     async run () {
@@ -45,6 +45,7 @@ class MochaAdapter {
         const mocha = new Mocha(this.config.mochaOpts)
         mocha.loadFiles()
         mocha.reporter(NOOP)
+        mocha.fullTrace()
         this.specs.forEach((spec) => mocha.addFile(spec))
 
         this.requireExternalModules(this.config.mochaOpts.compilers, this.config.mochaOpts.requires)
@@ -172,10 +173,13 @@ class MochaAdapter {
     }
 }
 
+const _MochaAdapter = MochaAdapter
 const adapterFactory = {}
-adapterFactory.run = async function mochaAdapter (cid, config, specs, capabilities) {
-    const adapter = new MochaAdapter(cid, config, specs, capabilities)
+
+adapterFactory.run = async function (cid, config, specs, capabilities) {
+    const adapter = new _MochaAdapter(cid, config, specs, capabilities)
     return await adapter.run()
 }
 
 export default adapterFactory
+export { MochaAdapter, adapterFactory }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -43,7 +43,6 @@ class MochaAdapter {
 
         const mocha = new Mocha(this.config.mochaOpts)
         mocha.loadFiles()
-        delete this.runner.lastError
         mocha.reporter(NOOP)
         this.specs.forEach((spec) => mocha.addFile(spec))
 
@@ -84,10 +83,10 @@ class MochaAdapter {
         ).then(() => done())
     }
 
-    prepareMessage (hookName, hookType) {
+    prepareMessage (hookName) {
         const params = { type: hookName }
 
-        switch (hookType) {
+        switch (hookName) {
         case 'beforeSuite':
         case 'afterSuite':
             params.payload = this.runner.suite.suites[0]
@@ -99,6 +98,7 @@ class MochaAdapter {
         }
 
         params.err = this.runner.lastError
+        delete this.runner.lastError
         return this.formatMessage(params)
     }
 
@@ -149,8 +149,6 @@ class MochaAdapter {
 
         if (err) {
             this.runner.lastError = err
-        } else if (event === 'test:start') {
-            delete this.runner.lastError
         }
         this.send(message)
     }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -49,9 +49,14 @@ class MochaAdapter {
 
         this.requireExternalModules(this.config.mochaOpts.compilers, this.config.mochaOpts.requires)
         wrapCommands(global.browser, this.config.beforeCommand, this.config.afterCommand)
-        mocha.suite.on('pre-require', () => INTERFACES[this.config.mochaOpts.ui].forEach(
-            runInFiberContext.bind(null, INTERFACES, this.config.mochaOpts.ui, this.config.beforeHook, this.config.afterHook))
-        )
+        mocha.suite.on('pre-require', () => INTERFACES[this.config.mochaOpts.ui].forEach((fnName) => {
+            runInFiberContext(
+                INTERFACES[this.config.mochaOpts.ui][2],
+                this.config.beforeHook,
+                this.config.afterHook,
+                fnName
+            )
+        }))
 
         await executeHooksWithArgs(this.config.before, [this.capabilities, this.specs])
         let result = await new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/webdriverio/wdio-mocha-framework#readme",
   "dependencies": {
     "mocha": "^2.3.3",
-    "wdio-sync": "0.0.1"
+    "wdio-sync": "^0.1.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -1,33 +1,17 @@
 import sinon from 'sinon'
-import adapter from '../lib/adapter'
+import { adapterFactory, MochaAdapter } from '../lib/adapter'
 
 /**
  * create mocks
  */
 const NOOP = function () {}
-let wrapCommand = sinon.spy()
-let runHook = sinon.spy()
 let Mocka = sinon.spy()
+
+let addFile = Mocka.prototype.addFile = sinon.spy()
 let loadFiles = Mocka.prototype.loadFiles = sinon.spy()
 let reporter = Mocka.prototype.reporter = sinon.stub()
 let run = Mocka.prototype.run = sinon.stub()
 let fullTrace = Mocka.prototype.fullTrace = sinon.stub()
-let originalCWD, load, send
-let config = {
-    onPrepare: NOOP,
-    before: NOOP,
-    beforeSuite: NOOP,
-    beforeHook: NOOP,
-    beforeTest: NOOP,
-    beforeCommand: NOOP,
-    afterCommand: NOOP,
-    afterTest: NOOP,
-    afterHook: NOOP,
-    afterSuite: NOOP,
-    after: NOOP,
-    onComplete: NOOP,
-    mochaOpts: {}
-}
 
 run.returns({
     on: NOOP,
@@ -38,73 +22,104 @@ run.returns({
         afterAll: NOOP
     }
 })
+
 Mocka.prototype.suite = { on: NOOP }
 
 describe('mocha adapter', () => {
     before(() => {
-        adapter.__Rewire__('Mocha', Mocka)
-        adapter.__Rewire__('runHook', runHook)
-        adapter.__Rewire__('wrapCommand', wrapCommand)
+        adapterFactory.__Rewire__('Mocha', Mocka)
+        adapterFactory.__Rewire__('wrapCommands', NOOP)
+        adapterFactory.__Rewire__('runInFiberContext', NOOP)
+        adapterFactory.__Rewire__('executeHooksWithArgs', NOOP)
+    })
 
-        load = adapter.load = sinon.spy()
-        send = adapter.send = sinon.spy()
+    describe('factory', () => {
+        let MockaAdapter = sinon.spy()
+        let run = MockaAdapter.prototype.run = sinon.spy()
 
-        originalCWD = process.cwd
-        Object.defineProperty(process, 'cwd', {
-            value: function () { return '/mypath' }
+        before(() => {
+            adapterFactory.__set__('_MochaAdapter', MockaAdapter)
+            adapterFactory.run(1, 2, 3, 4)
+        })
+
+        it('should create an adapter instance', () => {
+            MockaAdapter.calledWith(1, 2, 3, 4).should.be.true()
+        })
+
+        it('should immediatelly start run sequenz', () => {
+            run.called.should.be.true()
         })
     })
 
-    describe('can load external modules', () => {
-        it('should do nothing if no modules are required', () => {
-            adapter.requireExternalModules()
-        })
+    describe('MochaAdapter', () => {
+        let adapter, load, send, originalCWD
 
-        it('should load proper external modules', () => {
-            adapter.requireExternalModules(['js:moduleA', 'xy:moduleB'], ['yz:moduleC'])
-            load.calledWith('moduleA').should.be.true()
-            load.calledWith('moduleB').should.be.true()
-            load.calledWith('moduleC').should.be.true()
-        })
+        let config = { framework: 'mocha' }
+        let specs = ['fileA.js', 'fileB.js']
+        let caps = { browserName: 'chrome' }
 
-        it('should load local modules', () => {
-            adapter.requireExternalModules(['./lib/myModule'])
-            load.lastCall.args[0].slice(-20).should.be.exactly('/mypath/lib/myModule')
-        })
-    })
+        before(() => {
+            adapter = new MochaAdapter(1, config, specs, caps)
+            load = adapter.load = sinon.spy()
+            send = adapter.send = sinon.spy()
 
-    describe('sends event messages', () => {
-        it('should have proper message payload', () => {
-            let caps = { browserName: 'chrome' }
-            let err = { unAllowedProp: true }
-            adapter.emit('suite:start', {}, 0, caps, {}, err)
-            let msg = send.firstCall.args[0]
-            msg.runner['0'].should.be.exactly(caps)
-            msg.err.should.not.have.property('unAllowedProp')
-        })
-    })
-
-    describe('runs Mocha tests', () => {
-        it('should run return right amount of errors', () => {
-            let promise = adapter.run(0, config).then((failures) => {
-                failures.should.be.exactly(1234)
+            originalCWD = process.cwd
+            Object.defineProperty(process, 'cwd', {
+                value: function () { return '/mypath' }
             })
-            process.nextTick(() => run.callArgWith(0, 1234))
-            return promise
         })
 
-        it('should load files, wrap commands and run hooks', () => {
-            loadFiles.called.should.be.true()
-            reporter.called.should.be.true()
-            fullTrace.called.should.be.true()
-            wrapCommand.called.should.be.true()
-            runHook.called.should.be.true()
-        })
-    })
+        describe('can load external modules', () => {
+            it('should do nothing if no modules are required', () => {
+                adapter.requireExternalModules()
+                load.called.should.be.false()
+            })
 
-    after(() => {
-        Object.defineProperty(process, 'cwd', {
-            value: originalCWD
+            it('should load proper external modules', () => {
+                adapter.requireExternalModules(['js:moduleA', 'xy:moduleB'], ['yz:moduleC'])
+                load.calledWith('moduleA').should.be.true()
+                load.calledWith('moduleB').should.be.true()
+                load.calledWith('moduleC').should.be.true()
+            })
+
+            it('should load local modules', () => {
+                adapter.requireExternalModules(['./lib/myModule'])
+                load.lastCall.args[0].slice(-20).should.be.exactly('/mypath/lib/myModule')
+            })
+        })
+
+        describe('sends event messages', () => {
+            it('should have proper message payload', () => {
+                let err = { unAllowedProp: true, message: 'Uuups' }
+                adapter.emit('suite:start', config, err)
+                let msg = send.firstCall.args[0]
+                msg.runner[1].should.be.exactly(caps)
+                msg.err.should.not.have.property('unAllowedProp')
+                msg.err.message.should.be.exactly('Uuups')
+            })
+        })
+
+        describe('runs Mocha tests', () => {
+            it('should run return right amount of errors', () => {
+                let promise = adapter.run().then((failures) => {
+                    failures.should.be.exactly(1234)
+                })
+                process.nextTick(() => run.callArgWith(0, 1234))
+                return promise
+            })
+
+            it('should load files, wrap commands and run hooks', () => {
+                loadFiles.called.should.be.true()
+                addFile.called.should.be.true()
+                reporter.called.should.be.true()
+                fullTrace.called.should.be.true()
+            })
+        })
+
+        after(() => {
+            Object.defineProperty(process, 'cwd', {
+                value: originalCWD
+            })
         })
     })
 })

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -49,6 +49,10 @@ describe('mocha adapter', () => {
         it('should immediatelly start run sequenz', () => {
             run.called.should.be.true()
         })
+
+        after(() => {
+            adapterFactory.__ResetDependency__('_MochaAdapter')
+        })
     })
 
     describe('MochaAdapter', () => {
@@ -121,5 +125,12 @@ describe('mocha adapter', () => {
                 value: originalCWD
             })
         })
+    })
+
+    after(() => {
+        adapterFactory.__ResetDependency__('Mocha')
+        adapterFactory.__ResetDependency__('wrapCommands')
+        adapterFactory.__ResetDependency__('runInFiberContext')
+        adapterFactory.__ResetDependency__('executeHooksWithArgs')
     })
 })

--- a/test/fixtures/sample.conf.js
+++ b/test/fixtures/sample.conf.js
@@ -1,0 +1,180 @@
+global._wdio = {}
+
+export default {
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    mochaOpts: {
+        timeout: 5000
+    },
+
+    onPrepare: (...args) => {
+        global._wdio.onPrepare = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.onPrepare.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    before: (...args) => {
+        global._wdio.before = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.before.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    beforeSuite: (...args) => {
+        global._wdio.beforeSuite = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.beforeSuite.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    beforeHook: (...args) => {
+        global._wdio.beforeHook = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.beforeHook.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    afterHook: (...args) => {
+        global._wdio.afterHook = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.afterHook.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    beforeTest: (...args) => {
+        global._wdio.beforeTest = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.beforeTest.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    beforeCommand: (...args) => {
+        global._wdio.beforeCommand = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.beforeCommand.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    afterCommand: (...args) => {
+        global._wdio.afterCommand = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.afterCommand.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    afterTest: (...args) => {
+        global._wdio.afterTest = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.afterTest.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    afterSuite: (...args) => {
+        global._wdio.afterSuite = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.afterSuite.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    after: (...args) => {
+        global._wdio.after = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.after.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    },
+    onComplete: (...args) => {
+        global._wdio.onComplete = {
+            wasExecuted: true,
+            start: new Date().getTime(),
+            args
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                global._wdio.onComplete.end = new Date().getTime()
+                resolve()
+            }, 500)
+        })
+    }
+}

--- a/test/fixtures/sample.spec.js
+++ b/test/fixtures/sample.spec.js
@@ -1,0 +1,11 @@
+describe('dummy test', () => {
+    before(() => {
+    })
+
+    it('sample test', () => {
+        browser.command(1).should.be.equal(2)
+    })
+
+    after(() => {
+    })
+})

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -1,0 +1,221 @@
+import config from './fixtures/sample.conf'
+import adapterFactory from '../lib/adapter'
+
+const specs = ['./test/fixtures/sample.spec.js']
+const NOOP = () => {}
+
+const WebdriverIO = class {}
+WebdriverIO.prototype = {
+    command: (a) => new Promise((r) => {
+        setTimeout(() => r(a + 1), 2000)
+    })
+}
+global.browser = new WebdriverIO()
+
+process.send = NOOP
+
+describe('MochaAdapter executes hooks', () => {
+    before(async () => {
+        await adapterFactory.run(0, config, specs, config.capabilities)
+    })
+
+    describe('before', () => {
+        let beforeHook
+
+        before(() => beforeHook = global._wdio.before)
+
+        it('should get executed', () => {
+            beforeHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = beforeHook.end - beforeHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain capabilities and spec parameters', () => {
+            beforeHook.args[0].should.be.equal(config.capabilities)
+            beforeHook.args[1].should.be.equal(specs)
+        })
+    })
+
+    describe('beforeSuite', () => {
+        let beforeSuiteHook
+
+        before(() => beforeSuiteHook = global._wdio.beforeSuite)
+
+        it('should get executed', () => {
+            beforeSuiteHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = beforeSuiteHook.end - beforeSuiteHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain right suite data', () => {
+            let suite = beforeSuiteHook.args[0]
+            suite.type.should.be.equal('beforeSuite')
+            suite.title.should.be.equal('dummy test')
+        })
+    })
+
+    describe('beforeHook', () => {
+        let beforeHookHook
+
+        before(() => beforeHookHook = global._wdio.beforeHook)
+
+        it('should get executed', () => {
+            beforeHookHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = beforeHookHook.end - beforeHookHook.start
+            duration.should.be.greaterThan(490)
+        })
+    })
+
+    describe('afterHook', () => {
+        let afterHookHook
+
+        before(() => afterHookHook = global._wdio.afterHook)
+
+        it('should get executed', () => {
+            afterHookHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = afterHookHook.end - afterHookHook.start
+            duration.should.be.greaterThan(490)
+        })
+    })
+
+    describe('beforeTest', () => {
+        let beforeTestHook
+
+        before(() => beforeTestHook = global._wdio.beforeTest)
+
+        it('should get executed', () => {
+            beforeTestHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = beforeTestHook.end - beforeTestHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain right test data', () => {
+            let test = beforeTestHook.args[0]
+            test.type.should.be.equal('beforeTest')
+            test.title.should.be.equal('sample test')
+            test.parent.should.be.equal('dummy test')
+            test.passed.should.be.false()
+        })
+    })
+
+    describe('beforeCommand', () => {
+        let beforeCommandHook
+
+        before(() => beforeCommandHook = global._wdio.beforeCommand)
+
+        it('should get executed', () => {
+            beforeCommandHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = beforeCommandHook.end - beforeCommandHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain right command parameter', () => {
+            beforeCommandHook.args[0].should.be.equal('command')
+            beforeCommandHook.args[1][0].should.be.equal(1) // input
+        })
+    })
+
+    describe('afterCommand', () => {
+        let afterCommandHook
+
+        before(() => afterCommandHook = global._wdio.afterCommand)
+
+        it('should get executed', () => {
+            afterCommandHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = afterCommandHook.end - afterCommandHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain right command parameter', () => {
+            afterCommandHook.args[0].should.be.equal('command')
+            afterCommandHook.args[1][0].should.be.equal(1) // input
+            afterCommandHook.args[2].should.be.equal(2) // result
+        })
+    })
+
+    describe('afterTest', () => {
+        let afterTestHook
+
+        before(() => afterTestHook = global._wdio.afterTest)
+
+        it('should get executed', () => {
+            afterTestHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = afterTestHook.end - afterTestHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain right test data', () => {
+            let test = afterTestHook.args[0]
+            test.type.should.be.equal('afterTest')
+            test.title.should.be.equal('sample test')
+            test.parent.should.be.equal('dummy test')
+            test.duration.should.be.greaterThan(2990) // 2000ms command, 2 * 500ms hooks
+            test.passed.should.be.true()
+        })
+    })
+
+    describe('afterSuite', () => {
+        let afterSuiteHook
+
+        before(() => afterSuiteHook = global._wdio.afterSuite)
+
+        it('should get executed', () => {
+            afterSuiteHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = afterSuiteHook.end - afterSuiteHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain right suite data', () => {
+            let suite = afterSuiteHook.args[0]
+            suite.type.should.be.equal('afterSuite')
+            suite.title.should.be.equal('dummy test')
+        })
+    })
+
+    describe('after', () => {
+        let afterHook
+
+        before(() => afterHook = global._wdio.after)
+
+        it('should get executed', () => {
+            afterHook.wasExecuted.should.be.true()
+        })
+
+        it('should defer execution until promise was resolved', () => {
+            let duration = afterHook.end - afterHook.start
+            duration.should.be.greaterThan(490)
+        })
+
+        it('should contain capabilities and spec parameters', () => {
+            afterHook.args[0].should.be.equal(config.capabilities)
+            afterHook.args[1].should.be.equal(specs)
+        })
+    })
+})


### PR DESCRIPTION
@georgecrawford please review

This patch includes the following changes:
- rewritten adapter into a class to share data across methods
- minor tweaks due to wdio-sync package changes
- simplified adapter methods (less parameters)

Not all hooks are running through `wrapHook` anymore because I complicates stuff a lot. So command hooks get propagated when calling `wrapCommands` and hook hooks get propagated when overwriting `it` and test ui commands. The function now has a more dedicated job.

Missing in this PR and WIP: unit tests. Wanted to make sure that PRs get tested accordingly. So I am using the process to fix this too. 