### PR TITLE
Work around Mocha failure to determine Node env

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/webdriverio/wdio-mocha-framework#readme",
   "dependencies": {
-    "mocha": "^2.3.3",
+    "mocha": "berkerpeksag/mocha#1764",
     "wdio-sync": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@christian-bromann Not sure what you think about this.

Without the fix, I get:
```
ERROR: Couldn't load "mocha" framework. You need to install it with `$ npm install wdio-mocha-framework`! Error: TypeError: Cannot read property 'href' of undefined
    at Object.exports.stackTraceFilter (/Users/george/Desktop/wdio-for-jenkins/ft-app-webdriverio/node_modules/wdio-mocha-framework/node_modules/mocha/lib/utils.js:701:71)
    at Object.<anonymous> (/Users/george/Desktop/wdio-for-jenkins/ft-app-webdriverio/node_modules/wdio-mocha-framework/node_modules/mocha/lib/runner.js:14:25)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/Users/george/Desktop/wdio-for-jenkins/ft-app-webdriverio/node_modules/wdio-mocha-framework/node_modules/mocha/lib/mocha.js:40:18)
    at Module._compile (module.js:425:26)
```
...because mocha is mistakenly identifying a browser context rather than Node. The PR at https://github.com/mochajs/mocha/pull/1911 fixes it, but I don't like the idea of relying on this 3rd-party branch. Thoughts?