### PR TITLE
Allow the mocha reporter to run if explicitly configured.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -44,7 +44,10 @@ class MochaAdapter {
 
         const mocha = new Mocha(this.config.mochaOpts)
         mocha.loadFiles()
-        mocha.reporter(NOOP)
+        //if no reporter is configured, then prevent mocha from using its default reporter
+        if(!config.mochaOpts || !config.mochaOpts.reporter) {
+            mocha.reporter(NOOP)
+        }
         mocha.fullTrace()
         this.specs.forEach((spec) => mocha.addFile(spec))
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -45,7 +45,7 @@ class MochaAdapter {
         const mocha = new Mocha(this.config.mochaOpts)
         mocha.loadFiles()
         //if no reporter is configured, then prevent mocha from using its default reporter
-        if(!config.mochaOpts || !config.mochaOpts.reporter) {
+        if(!this.config.mochaOpts || !this.config.mochaOpts.reporter) {
             mocha.reporter(NOOP)
         }
         mocha.fullTrace()

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -44,8 +44,8 @@ class MochaAdapter {
 
         const mocha = new Mocha(this.config.mochaOpts)
         mocha.loadFiles()
-        //if no reporter is configured, then prevent mocha from using its default reporter
-        if(!this.config.mochaOpts || !this.config.mochaOpts.reporter) {
+        // If no reporter is configured, then prevent mocha from using its default reporter
+        if (!this.config.mochaOpts || !this.config.mochaOpts.reporter) {
             mocha.reporter(NOOP)
         }
         mocha.fullTrace()


### PR DESCRIPTION
This gives the user more flexibility with regard to reporting. They can use one of mocha's built in reporters or a third party mocha reporter if they wish. It's a non-breaking change and users will see no difference in behaviour unless they add explicit reporter configuration in 'mochaOpts'.