### PR TITLE
Context for mochaOpts.requires

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,5 @@
   "parser": "babel-eslint",
   "rules": {
     "indent": [2, 4]
-  },
-  "parser": "babel-eslint"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -45,4 +45,56 @@ Options will be passed to the Mocha instance. See the full list of Mocha options
 
 ----
 
+## `mochaOpts.requires`
+
+The `requires` option is useful when you want to add or extend some basic functionality.
+For example, let's try to create an anonymous `describe`:
+
+**wdio.conf.js**
+
+```js
+{
+  mochaOpts: {
+    requires: './hooks/mocha.js'
+  }
+}
+```
+
+**./hooks/mocha.js**
+
+```js
+import path from 'path';
+
+let { context, file, mocha, options } = module.parent.context;
+let { describe } = context;
+
+context.describe = function (name, callback) {
+	if (callback) {
+		return describe(...arguments);
+	} else {
+		callback = name;
+		name = path.basename(file, '.js');
+
+		return describe(name, callback);
+	}
+}
+```
+
+**./tests/suite.js**
+
+```js
+describe(() => {
+	it('test_case', () => {
+		this.skip();
+	});
+});
+```
+
+**Output**
+
+```
+suite
+   ✓ test_case
+```
+
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -38,27 +38,37 @@ class MochaAdapter {
     }
 
     async run () {
-        if (typeof this.config.mochaOpts.ui !== 'string' || !INTERFACES[this.config.mochaOpts.ui]) {
+        let {mochaOpts} = this.config
+
+        if (typeof mochaOpts.ui !== 'string' || !INTERFACES[mochaOpts.ui]) {
             this.config.mochaOpts.ui = 'bdd'
         }
 
-        const mocha = new Mocha(this.config.mochaOpts)
+        const mocha = new Mocha(mochaOpts)
         mocha.loadFiles()
         mocha.reporter(NOOP)
         mocha.fullTrace()
         this.specs.forEach((spec) => mocha.addFile(spec))
 
-        this.requireExternalModules(this.config.mochaOpts.compilers, this.config.mochaOpts.requires)
         wrapCommands(global.browser, this.config.beforeCommand, this.config.afterCommand)
-        mocha.suite.on('pre-require', () => INTERFACES[this.config.mochaOpts.ui].forEach((fnName) => {
-            let testCommand = INTERFACES[this.config.mochaOpts.ui][2]
-            runInFiberContext(
-                [testCommand, testCommand + '.only'],
-                this.config.beforeHook,
-                this.config.afterHook,
-                fnName
-            )
-        }))
+
+        mocha.suite.on('pre-require', (context, file, mocha) => {
+            this.requireExternalModules([
+                mochaOpts.compilers,
+                mochaOpts.requires
+            ], { context, file, mocha, options: mochaOpts })
+
+            INTERFACES[mochaOpts.ui].forEach((fnName) => {
+                let testCommand = INTERFACES[mochaOpts.ui][2]
+
+                runInFiberContext(
+                    [testCommand, testCommand + '.only'],
+                    this.config.beforeHook,
+                    this.config.afterHook,
+                    fnName
+                )
+            })
+        })
 
         await executeHooksWithArgs(this.config.before, [this.capabilities, this.specs])
         let result = await new Promise((resolve, reject) => {
@@ -149,16 +159,18 @@ class MochaAdapter {
         return message
     }
 
-    requireExternalModules (compilers = [], requires = []) {
-        compilers.concat(requires).forEach((mod) => {
-            mod = mod.split(':')
-            mod = mod[mod.length - 1]
+    requireExternalModules (modules = [], context) {
+        modules.forEach((mod) => {
+            if (mod) {
+                mod = mod.split(':')
+                mod = mod[mod.length - 1]
 
-            if (mod[0] === '.') {
-                mod = path.join(process.cwd(), mod)
+                if (mod[0] === '.') {
+                    mod = path.join(process.cwd(), mod)
+                }
+
+                this.load(mod, context)
             }
-
-            this.load(mod)
         })
     }
 
@@ -199,9 +211,10 @@ class MochaAdapter {
         return process.send.apply(process, args)
     }
 
-    load (module) {
+    load (name, context) {
         try {
-            require(module)
+            module.context = context
+            require(name)
         } catch (e) {
             throw new Error(`Module ${module} can't get loaded. Are you sure you have installed it?\n` +
                             `Note: if you've installed WebdriverIO globally you need to install ` +

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -84,15 +84,21 @@ describe('mocha adapter', () => {
             })
 
             it('should load proper external modules', () => {
-                adapter.requireExternalModules(['js:moduleA', 'xy:moduleB'], ['yz:moduleC'])
+                adapter.requireExternalModules(['js:moduleA', 'xy:moduleB'])
                 load.calledWith('moduleA').should.be.true()
                 load.calledWith('moduleB').should.be.true()
-                load.calledWith('moduleC').should.be.true()
             })
 
             it('should load local modules', () => {
                 adapter.requireExternalModules(['./lib/myModule'])
                 load.lastCall.args[0].slice(-20).should.be.exactly('/mypath/lib/myModule')
+            })
+
+            it('should load a module with context', () => {
+                let context = { context: true }
+
+                adapter.requireExternalModules(['js:moduleA'], context)
+                load.calledWith('moduleA', context).should.be.true()
             })
         })
 


### PR DESCRIPTION
## `mochaOpts.requires`

The `requires` option is useful when you want to add or extend some basic functionality.
For example, let's try to create an anonymous `describe`:

**wdio.conf.js**

```js
{
  mochaOpts: {
    requires: './hooks/mocha.js'
  },

  suites: {
    login: ['tests/login/*.js']
  }
}
```

**./hooks/mocha.js**

```js
import path from 'path';

let { context, file } = module.parent.context;
let { describe } = context;

context.describe = function (name, callback) {
	if (callback) {
		return describe(...arguments);
	} else {
		callback = name;
		name = path.basename(file, '.js');

		return describe(name, callback);
	}
}
```

**./tests/login/TESTMAIL-87767.js**

```js
describe(() => {
	it('Login form', () => {
              ....
	});
});
```

**Output**

```
TESTMAIL-87767
   ✓ Login form
```

@christian-bromann 