### PR TITLE
Wdio spec reporter issues 11

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -50,6 +50,12 @@ class MochaAdapter {
 
         this.sentMessages = 0 // number of messages sent to the parent
         this.receivedMessages = 0 // number of messages received by the parent
+        this.messageCounter = 0
+        this.messageUIDs = {
+            suite: {},
+            hook: {},
+            test: {}
+        }
     }
 
     options (options, context) {
@@ -234,7 +240,7 @@ class MochaAdapter {
     generateUID (message) {
         switch (message.type) {
         case 'suite:start':
-            message.uid = this.getUID(message.title, 'suite_start')
+            message.uid = this.getUID(message.title, 'suite', true)
             message.parent = message.uid
             break
 
@@ -244,7 +250,7 @@ class MochaAdapter {
             break
 
         case 'hook:start':
-            message.uid = this.getUID(message.title, 'hook_start')
+            message.uid = this.getUID(message.title, 'hook', true)
             message.parent = this.getUID(message.parent, 'suite')
             break
 
@@ -254,7 +260,7 @@ class MochaAdapter {
             break
 
         case 'test:start':
-            message.uid = this.getUID(message.title, 'test_start')
+            message.uid = this.getUID(message.title, 'test', true)
             message.parent = this.getUID(message.parent, 'suite')
             break
 
@@ -273,14 +279,8 @@ class MochaAdapter {
         return message
     }
 
-    getUID (title, type) {
-        if (type === 'test_start') {
-            type = 'test'
-        } else if (type === 'hook_start') {
-            type = 'hook'
-        } else if (type === 'suite_start') {
-            type = 'suite'
-        } else if (this.messageUIDs[type][title]) {
+    getUID (title, type, start) {
+        if (start !== true && this.messageUIDs[type][title]) {
             return this.messageUIDs[type][title]
         }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -224,7 +224,9 @@ class MochaAdapter {
             this.runner.lastError = err
         }
 
-        message = this.generateUID(message)
+        let {uid, parentUid} = this.generateUID(message)
+        message.uid = uid
+        message.parent = parentUid
 
         // When starting a new test, propagate the details to the test runner so that
         // commands, results, screenshots and hooks can be associated with this test
@@ -238,45 +240,50 @@ class MochaAdapter {
     }
 
     generateUID (message) {
+        var uid, parentUid
+
         switch (message.type) {
         case 'suite:start':
-            message.uid = this.getUID(message.title, 'suite', true)
-            message.parent = message.uid
+            uid = this.getUID(message.title, 'suite', true)
+            parentUid = uid
             break
 
         case 'suite:end':
-            message.uid = this.getUID(message.title, 'suite')
-            message.parent = message.uid
+            uid = this.getUID(message.title, 'suite')
+            parentUid = uid
             break
 
         case 'hook:start':
-            message.uid = this.getUID(message.title, 'hook', true)
-            message.parent = this.getUID(message.parent, 'suite')
+            uid = this.getUID(message.title, 'hook', true)
+            parentUid = this.getUID(message.parent, 'suite')
             break
 
         case 'hook:end':
-            message.uid = this.getUID(message.title, 'hook')
-            message.parent = this.getUID(message.parent, 'suite')
+            uid = this.getUID(message.title, 'hook')
+            parentUid = this.getUID(message.parent, 'suite')
             break
 
         case 'test:start':
-            message.uid = this.getUID(message.title, 'test', true)
-            message.parent = this.getUID(message.parent, 'suite')
+            uid = this.getUID(message.title, 'test', true)
+            parentUid = this.getUID(message.parent, 'suite')
             break
 
         case 'test:pending':
         case 'test:end':
         case 'test:pass':
         case 'test:fail':
-            message.uid = this.getUID(message.title, 'test')
-            message.parent = this.getUID(message.parent, 'suite')
+            uid = this.getUID(message.title, 'test')
+            parentUid = this.getUID(message.parent, 'suite')
             break
 
         default:
             throw new Error(`Unknown message type : ${message.type}`)
         }
 
-        return message
+        return {
+            uid,
+            parentUid
+        }
     }
 
     getUID (title, type, start) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -160,6 +160,7 @@ class MochaAdapter {
 
         if (params.payload) {
             message.title = params.payload.title
+            message.uid = params.payload.title
             message.parent = params.payload.parent ? params.payload.parent.title : null
 
             /**
@@ -209,7 +210,6 @@ class MochaAdapter {
         let message = this.formatMessage({type: event, payload, err})
 
         message.cid = this.cid
-        message.uid = payload.title
         message.specs = this.specs
         message.event = event
         message.runner = {}

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -160,7 +160,6 @@ class MochaAdapter {
 
         if (params.payload) {
             message.title = params.payload.title
-            message.uid = params.payload.title
             message.parent = params.payload.parent ? params.payload.parent.title : null
 
             /**
@@ -219,6 +218,8 @@ class MochaAdapter {
             this.runner.lastError = err
         }
 
+        message = this.generateUID(message)
+
         // When starting a new test, propagate the details to the test runner so that
         // commands, results, screenshots and hooks can be associated with this test
         if (event === 'test:start') {
@@ -228,6 +229,66 @@ class MochaAdapter {
         if (this.send(message, null, {}, () => ++this.receivedMessages)) {
             this.sentMessages++
         }
+    }
+
+    generateUID (message) {
+        switch (message.type) {
+        case 'suite:start':
+            message.uid = this.getUID(message.title, 'suite_start')
+            message.parent = message.uid
+            break
+
+        case 'suite:end':
+            message.uid = this.getUID(message.title, 'suite')
+            message.parent = message.uid
+            break
+
+        case 'hook:start':
+            message.uid = this.getUID(message.title, 'hook_start')
+            message.parent = this.getUID(message.parent, 'suite')
+            break
+
+        case 'hook:end':
+            message.uid = this.getUID(message.title, 'hook')
+            message.parent = this.getUID(message.parent, 'suite')
+            break
+
+        case 'test:start':
+            message.uid = this.getUID(message.title, 'test_start')
+            message.parent = this.getUID(message.parent, 'suite')
+            break
+
+        case 'test:pending':
+        case 'test:end':
+        case 'test:pass':
+        case 'test:fail':
+            message.uid = this.getUID(message.title, 'test')
+            message.parent = this.getUID(message.parent, 'suite')
+            break
+
+        default:
+            throw new Error(`Unknown message type : ${message.type}`)
+        }
+
+        return message
+    }
+
+    getUID (title, type) {
+        if (type === 'test_start') {
+            type = 'test'
+        } else if (type === 'hook_start') {
+            type = 'hook'
+        } else if (type === 'suite_start') {
+            type = 'suite'
+        } else if (this.messageUIDs[type][title]) {
+            return this.messageUIDs[type][title]
+        }
+
+        let uid = title + this.messageCounter++
+
+        this.messageUIDs[type][title] = uid
+
+        return uid
     }
 
     sendInternal (event, message) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -209,6 +209,7 @@ class MochaAdapter {
         let message = this.formatMessage({type: event, payload, err})
 
         message.cid = this.cid
+        message.uid = payload.title
         message.specs = this.specs
         message.event = event
         message.runner = {}

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -118,7 +118,7 @@ describe('mocha adapter', () => {
                 let msg = send.firstCall.args[0]
                 msg.type.should.be.exactly('suite:start')
                 msg.cid.should.be.exactly(cid)
-                msg.uid.should.be.equal(title)
+                msg.uid.should.startWith(title)
                 msg.specs.should.be.exactly(specs)
                 msg.runner[cid].should.be.exactly(caps)
                 msg.err.should.not.have.property('unAllowedProp')
@@ -137,7 +137,7 @@ describe('mocha adapter', () => {
 
                 let msg = sendInternal.firstCall.args[1]
                 msg.cid.should.be.exactly(cid)
-                msg.uid.should.be.equal(title)
+                msg.uid.should.startWith(title)
                 msg.specs.should.be.exactly(specs)
                 msg.runner[cid].should.be.exactly(caps)
             })
@@ -173,8 +173,8 @@ describe('mocha adapter', () => {
                 (end - start).should.be.greaterThan(500)
                 failures.should.be.exactly(1234)
             })
-            adapter.emit('foobar', {}, {})
-            adapter.emit('foobar2', {}, {})
+            adapter.emit('suite:start', {}, {})
+            adapter.emit('suite:end', {}, {})
             process.nextTick(() => run.callArgWith(0, 1234))
 
             setTimeout(() => {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -59,7 +59,8 @@ describe('mocha adapter', () => {
         let adapter, load, send, sendInternal, originalCWD
 
         let cid = 1
-        let config = { framework: 'mocha' }
+        const title = 'mocha-tests'
+        let config = { framework: 'mocha', title: title }
         let specs = ['fileA.js', 'fileB.js']
         let caps = { browserName: 'chrome' }
 
@@ -117,6 +118,7 @@ describe('mocha adapter', () => {
                 let msg = send.firstCall.args[0]
                 msg.type.should.be.exactly('suite:start')
                 msg.cid.should.be.exactly(cid)
+                msg.uid.should.be.equal(title)
                 msg.specs.should.be.exactly(specs)
                 msg.runner[cid].should.be.exactly(caps)
                 msg.err.should.not.have.property('unAllowedProp')
@@ -135,6 +137,7 @@ describe('mocha adapter', () => {
 
                 let msg = sendInternal.firstCall.args[1]
                 msg.cid.should.be.exactly(cid)
+                msg.uid.should.be.equal(title)
                 msg.specs.should.be.exactly(specs)
                 msg.runner[cid].should.be.exactly(caps)
             })


### PR DESCRIPTION
**Please note:** this PR is required for fixing issue [#11 reported in the wdio-spec-reporter](https://github.com/webdriverio/wdio-spec-reporter/issues/11) repo, please refer to that issue for more details.

In order to identify each suite & spec when reporting back to the user I added a UID, which is composed from the name of the suite/spec (since there seems to be no other "unique" element). 

This is **not** a breaking change! (since we did not change the title of the parent) But it is required if you use the next version of WDIO (see the issue mentioned above)