### PR TITLE
Added ^ for wdio-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/webdriverio/wdio-mocha-framework#readme",
   "dependencies": {
     "mocha": "^2.3.3",
-    "wdio-sync": "0.5.6",
+    "wdio-sync": "^0.5.7",
     "babel-runtime": "^5.8.25"
   },
   "devDependencies": {


### PR DESCRIPTION
It would be helpful for people who wants to use `wdio-sync` being published in their local registries. 
For example, I can't wait when any [release](https://github.com/webdriverio/wdio-sync/pull/42) will be published, but I can fix myself and use a custom version from my local registry.