### PR TITLE
Added a seperate parentUid to make sure we have both the parent title…

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -227,7 +227,7 @@ class MochaAdapter {
 
         let {uid, parentUid} = this.generateUID(message)
         message.uid = uid
-        message.parent = parentUid
+        message.parentUid = parentUid
 
         // When starting a new test, propagate the details to the test runner so that
         // commands, results, screenshots and hooks can be associated with this test


### PR DESCRIPTION
This will fix the suite name having an appended UID as mentioned [here](https://github.com/webdriverio/wdio-spec-reporter/issues/11#issuecomment-266849193)

It is  a none breaking fix and relates to [this PR](https://github.com/webdriverio/webdriverio/pull/1767) for WebdriverIO