### PR TITLE
Add fullTitle to message

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -176,6 +176,7 @@ class MochaAdapter {
                 message.parent = params.payload.parent.suites[0].title
             }
 
+            message.fullTitle = params.payload.fullTitle ? params.payload.fullTitle() : message.parent + ' ' + message.title
             message.pending = params.payload.pending || false
             message.file = params.payload.file
 

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -129,6 +129,7 @@ describe('MochaAdapter executes hooks using native Promises', () => {
             let test = beforeTestHook.args[0]
             test.type.should.be.equal('beforeTest')
             test.title.should.be.equal('sample test')
+            test.fullTitle.should.be.equal('dummy test sample test')
             test.parent.should.be.equal('dummy test')
             test.passed.should.be.false()
         })
@@ -193,6 +194,7 @@ describe('MochaAdapter executes hooks using native Promises', () => {
             let test = afterTestHook.args[0]
             test.type.should.be.equal('afterTest')
             test.title.should.be.equal('sample test')
+            test.fullTitle.should.be.equal('dummy test sample test')
             test.parent.should.be.equal('dummy test')
             test.duration.should.be.greaterThan(2990) // 2000ms command, 2 * 500ms hooks
             test.passed.should.be.true()


### PR DESCRIPTION
Useful for the dot-reporter and nested `describe`. Currently, only the first parent's title is retrieved in the report message, which is not the behavior we can expect.

It would be even better to provide full access to the `currentTest` property (`message.currentTest = params.payload.ctx.currentTest` instead of `message.currentTest = params.payload.ctx.currentTest.title`) but it would probably break backward compatibility.
