### PR TITLE
Update docs to only reference supported Mocha opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ module.exports = {
 
 ## `mochaOpts` Options
 
-Options will be passed to the Mocha instance. See the full list of Mocha options at [http://mochajs.org/](http://mochajs.org/)
+Options will be passed to the Mocha instance. See the list of supported Mocha options [here](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options).
 
 ----
 


### PR DESCRIPTION
Since Mocha is being used programmatically, not all of the command-line options documented at http://mochajs.org/ are supported. Updating README.md to point to the smaller set of Mocha options that are supported.

If there's a way the full list of Mocha options could be supported, that would be amazing. For example, it would be great to have access to `--no-timeouts` and `--debug`