### PR TITLE
feature(): partially support third party mocha interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ module.exports = {
 
 Options will be passed to the Mocha instance. See the list of supported Mocha options [here](https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options).
 
+Note that interfaces supported are `bdd`, `tdd` and `qunit`. If you want to provide a custom interface, it should expose methods compatible with them and be named ending with `-bdd`, `-tdd` or `-qunit` accordingly.
+
 ----
 
 ## `mochaOpts.require (string|string[])`

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -4,9 +4,9 @@ import Mocha from 'mocha'
 import { runInFiberContext, wrapCommands, executeHooksWithArgs } from 'wdio-sync'
 
 const INTERFACES = {
-    bdd: ['before', 'beforeEach', 'it', 'after', 'afterEach'],
-    tdd: ['suiteSetup', 'setup', 'test', 'suiteTeardown', 'teardown'],
-    qunit: ['before', 'beforeEach', 'test', 'after', 'afterEach']
+    bdd: ['it', 'before', 'beforeEach', 'after', 'afterEach'],
+    tdd: ['test', 'suiteSetup', 'setup', 'suiteTeardown', 'teardown'],
+    qunit: ['test', 'before', 'beforeEach', 'after', 'afterEach']
 }
 
 const EVENTS = {
@@ -23,6 +23,18 @@ const EVENTS = {
 
 const NOOP = function () {}
 const SETTLE_TIMEOUT = 5000
+
+/**
+ * Extracts the mocha UI type following this convention:
+ *  - If the mochaOpts.ui provided doesn't contain a '-' then the full name
+ *      is taken as ui type (i.e. 'bdd','tdd','qunit')
+ *  - If it contains a '-' then it asumes we are providing a custom ui for
+ *      mocha. Then it extracts the text after the last '-' (ignoring .js if
+ *      provided) as the interface type. (i.e. strong-bdd in
+ *      https://github.com/strongloop/strong-mocha-interfaces)
+ */
+const MOCHA_UI_TYPE_EXTRACTOR = /^(?:.*-)?([^-.]+)(?:.js)?$/
+const DEFAULT_INTERFACE_TYPE = 'bdd'
 
 /**
  * Mocha runner
@@ -72,9 +84,8 @@ class MochaAdapter {
     async run () {
         let {mochaOpts} = this.config
 
-        if (typeof mochaOpts.ui !== 'string' || !INTERFACES[mochaOpts.ui]) {
-            mochaOpts.ui = 'bdd'
-        }
+        const match = MOCHA_UI_TYPE_EXTRACTOR.exec(mochaOpts.ui)
+        const type = (match && INTERFACES[match[1]] && match[1]) || DEFAULT_INTERFACE_TYPE
 
         const mocha = new Mocha(mochaOpts)
         mocha.loadFiles()
@@ -89,8 +100,8 @@ class MochaAdapter {
                 context, file, mocha, options: mochaOpts
             })
 
-            INTERFACES[mochaOpts.ui].forEach((fnName) => {
-                let testCommand = INTERFACES[mochaOpts.ui][2]
+            INTERFACES[type].forEach((fnName) => {
+                let testCommand = INTERFACES[type][0]
 
                 runInFiberContext(
                     [testCommand, testCommand + '.only'],


### PR DESCRIPTION
We are in the need of including a third party interface for mocha and we cannot achieve that due to this mocha adapter restricting mochaOpts.ui.

This PR aims to partially support third party interfaces as long as they expose methods compatible with either bdd, tdd or qunit and are named ending with bdd, tdd, qunit accordingly.

Thanks!